### PR TITLE
Make gendocs ignore *.min.js + correct docco dependency in package.json

### DIFF
--- a/lib/anvil.js
+++ b/lib/anvil.js
@@ -520,13 +520,15 @@ generate_docs_for_file = function(dir, file, done) {
   file_path = path.join(dir, file);
   conf = config.gendocs;
   return path.exists(file_path, function(exists) {
-    if (exists) {
+    if (exists && file_path.match(/(\.js|\.coffee)$/) && !(file_path.match(/\.min\./))) {
       return fs.readFile(file_path, function(err, file_contents) {
         onStep('Generating docs for ' + file_path);
         return generate_docs_from_string(file_contents.toString(), file, done);
       });
     } else {
-      return onError(file_path, 'does not exist!');
+      if (!exists) {
+        return onError(file_path, 'does not exist!');
+      }
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "argparser": "0.0.9",
         "socket.io": ">=0.8.4",
         "ape": ">=0.3.6",
-        "docco": ">=0.3.0" 
+        "docco": "https://github.com/andtan/flocco/tarball/master" 
     },
     "preferGlobal": true,
     "bin": {

--- a/src/gendocs.coffee
+++ b/src/gendocs.coffee
@@ -47,13 +47,14 @@ generate_docs_for_file = (dir, file, done) ->
 	file_path = path.join(dir, file)
 	conf = config.gendocs
 	path.exists(file_path, (exists) -> 
-		if exists
+		if exists and file_path.match(/(\.js|\.coffee)$/) and not (file_path.match /\.min\./)
 			fs.readFile(file_path, (err, file_contents) -> 
 				onStep 'Generating docs for ' + file_path
 				generate_docs_from_string file_contents.toString(), file, done
 			)
 		else
-			onError file_path, 'does not exist!'
+			unless exists
+				onError file_path, 'does not exist!'
 	)
 
 # ## get_doc_generator_method ##


### PR DESCRIPTION
- Changes to gendocs (and thus to anvil.js) to ignore minified files
- Changed docco entiry in package.json to point to @andtan's fork of docco that supports use by other libs.
