### PR TITLE
0.7.8 - Support for relative import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,15 @@ or by adding a "mocha" configuration block to your build.json file.
 You can tell anvil to run in quiet mode (it will still print errors (red) and step completions (green) )
 
     anvil -q
+
+# Contributors
+
+Special thanks to the following individuals who have contributed source code or ideas to help make Anvil.js less buggy and more useful:
+
+ * Jim Cowart
+ * Aaron McCall
+ * Mike Stenhouse
+ * Robert Messerle
+ * Mike Hostetler
+ * Doug Neiner
+ * Derick Bailey

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,58 @@
+# Anvil.js Change Log
+
+## 0.7.8
+
+Added support for relative import statements. (thanks @robertmesserle for helping with ideas and pushing me to get this done). Don't prefix the import path with a ./ or /, Anvil won't recognize that as a match.
+
+### Examples of (now valid) import statements:
+
+__To import a file in the same directory:__
+	// import( "child.js" );
+
+__To import a file from a subdirectory:__
+	// import( "subdir/child.js" );
+
+__To import a file from a parent directory:__
+	// import( "../parent.js" );
+
+__To import a file from a sibling directory:__
+	// import( "../sibling/file.js" );
+
+
+## 0.7.7
+
+Removed support for docco since the flocco repository disappeared from NPM and GitHub. The original docco package requires python and a python package to be installed. This feels too heavy a requirement to install Anvil (which already has a lot of dependencies).
+
+## 0.7.6
+
+Addressed issues: #28, #29 and #30 (thanks @mikesten)
+
+ * Fixed issues with the combiner's regular expressions that caused issues with jQuery's $
+ * Fixed a bug in how the minification was mangling the creation of minified file names
+
+## 0.7.5
+
+###Issues
+ * #18 - ENOENT error on creating project scaffold (thanks @mikehostetler and @ifandelse)
+ * #22 - No longer copying files to user's ext folder. Anvil's browser dependencies (for QUnit support) are now available via relative url. (thanks @barclayadam)
+ 	* jquery -> /anvil/jquery.js
+ 	* qunit -> /anvil/qunit.js, /anvil/qunit.css
+ 	* pavlov -> /anvil/pavlov.js
+ 	* anvilHook -> /anvil/anvilHook.js
+ * #23 - ENOENT was occurring and not caught in CI mode because of symbolic links (thanks @yesimon)
+
+ ### Experimental Uglify Exclusions
+
+
+ ### Parallel Development for Anvil 0.8.*
+
+## 0.7.4
+
+ * Added --help option to command line
+ * Bug fix for Mocha in CI mode to force re-load of source files
+ * Bug fix for CI mode that caused multiple builds to kick off on file change
+ * CLI went from big ugly function to a proper module
+
+## 0.7.3
+
+ * Bug fix to prevent Anvil from trying to "BUILD ALL THE THINGS" when it had no idea how to process every file it found.

--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,11 @@
+# Contributors
+
+Special thanks to the following individuals who have contributed source code or ideas to help make Anvil.js less buggy and more useful:
+
+ * Jim Cowart
+ * Aaron McCall
+ * Mike Stenhouse
+ * Robert Messerle
+ * Mike Hostetler
+ * Doug Neiner
+ * Derick Bailey

--- a/docs/anvil.html
+++ b/docs/anvil.html
@@ -901,7 +901,6 @@ path = require <span class="string">"path"</span>
 				importedFile = _.find( list, ( i ) -> 
 					relativeImportPath = path.relative( path.dirname( file.fullPath ), path.dirname( i.fullPath ) )
 					relativeImport = self.fp.buildPath( [ relativeImportPath, i.name ] )
-					console.log "relative #{ relativeImport } actual #{ importName }"
 					relativeImport == importName )
 				file.imports.push importedFile
 			onComplete()
@@ -973,7 +972,7 @@ path = require <span class="string">"path"</span>
 					fullPattern = <span class="keyword">new</span> RegExp stringified, <span class="string">"g"</span>					
 					capture = fullPattern.exec<span class="params">( content )</span>
 					<span class="keyword">if</span> capture <span class="keyword">and</span> capture.length > <span class="number">1</span></code></pre></td></tr><tr class="block"><td class="comment"><p>capture the indentation of the import</p></td><td class="code"><pre><code>						whiteSpace = capture[<span class="number">1</span>]</code></pre></td></tr><tr class="block"><td class="comment"><p>apply indentation to all lines of the new content</p></td><td class="code"><pre><code>						newContent = <span class="string">"<span class="subst">#{ whiteSpace }</span>"</span> + newContent.replace ///\n///g, <span class="string">"\n<span class="subst">#{ whiteSpace }</span>"</span>
-					sanitized = current.replace<span class="params">( fullPattern, newContent.replace( <span class="string">"\$"</span>, <span class="string">"$"</span> )</span> ).replace<span class="params">( <span class="string">"$"</span>, <span class="string">"$"</span> )</span>
+					sanitized = current.replace<span class="params">( fullPattern, newContent.replace( <span class="string">"\$"</span>, <span class="string">"dollarh"</span> )</span> ).replace<span class="params">( <span class="string">"dollarh"</span>, <span class="string">"$"</span> )</span>
 					done sanitized
 			pipe content, steps, <span class="params">( result )</span> <span class="function">-></span>
 				onComp<span class="reserved">let</span>e result

--- a/docs/anvil.html
+++ b/docs/anvil.html
@@ -131,7 +131,7 @@ extensionLookup =
 		self = <span class="keyword">this</span>
 		command = <span class="keyword">new</span> Commander<span class="params">()</span>
 		command
-			.version<span class="params">(<span class="string">"0.7.6"</span>)</span>
+			.version<span class="params">(<span class="string">"0.7.7"</span>)</span>
 			.option<span class="params">( <span class="string">"-b, --build [build file]"</span>, <span class="string">"Use a custom build file"</span>, <span class="string">"./build.json"</span> )</span>
 			.option<span class="params">( <span class="string">"--ci"</span>, <span class="string">"Run a continuous integration build"</span> )</span>
 			.option<span class="params">( <span class="string">"--host"</span>, <span class="string">"Setup a static HTTP host"</span> )</span>
@@ -825,6 +825,7 @@ marked.setOptions { sanitize: <span class="literal">false</span> }
 <span class="reserved">export</span>s.compiler = Compiler
 
 _ = require <span class="string">"underscore"</span>
+path = require <span class="string">"path"</span>
 </code></pre></td></tr><tr class="block"><td class="comment"><h2>Combiner</h2>
 
 <p>Combines imports with the files importing them</p></td><td class="code"><pre><code><span class="keyword">class</span> Combiner
@@ -898,7 +899,10 @@ _ = require <span class="string">"underscore"</span>
 			<span class="reserved">import</span>s = _.filter <span class="reserved">import</span>s, <span class="params">( x )</span> <span class="function">-></span> x</code></pre></td></tr><tr class="block"><td class="comment"><p>strip out all the raw file names from the import statements<br />find the matching file metadata for the import</p></td><td class="code"><pre><code>			for imported in imports
 				importName = ( imported.match ///['\"].*['\"]/// )[ 0 ].replace(///['\"]///g, "" )
 				importedFile = _.find( list, ( i ) -> 
-					i.name == importName )
+					relativeImportPath = path.relative( path.dirname( file.fullPath ), path.dirname( i.fullPath ) )
+					relativeImport = self.fp.buildPath( [ relativeImportPath, i.name ] )
+					console.log "relative #{ relativeImport } actual #{ importName }"
+					relativeImport == importName )
 				file.imports.push importedFile
 			onComplete()
 </code></pre></td></tr><tr class="block"><td class="comment"><h2>fileDependents</h2>
@@ -913,7 +917,7 @@ _ = require <span class="string">"underscore"</span>
 <li><em>onComplete {Function}</em>: callback to invoke on completion</li>
 </ul></td><td class="code"><pre><code>	findDependents: <span class="params">( file, list )</span> <span class="function">-></span>
 		<span class="reserved">import</span>ed = <span class="params">( importFile )</span> <span class="function">-></span>
-			file.name == <span class="reserved">import</span>File.name
+			file.fullPath == <span class="reserved">import</span>File.fullPath
 		<span class="keyword">for</span> item <span class="keyword">in</span> list
 			<span class="keyword">if</span> _.any item.<span class="reserved">import</span>s, <span class="reserved">import</span>ed <span class="keyword">then</span> file.dependents++
 </code></pre></td></tr><tr class="block"><td class="comment"><h2>combine</h2>
@@ -931,7 +935,7 @@ _ = require <span class="string">"underscore"</span>
 			pipe = @scheduler.pipeline
 			fp = @fp
 			<span class="keyword">if</span> file.<span class="reserved">import</span>s.length > <span class="number">0</span></code></pre></td></tr><tr class="block"><td class="comment"><p>creates a closure around a specific import to prevent<br />access to a changing variable</p></td><td class="code"><pre><code>				steps = <span class="keyword">for</span> <span class="reserved">import</span>ed <span class="keyword">in</span> file.<span class="reserved">import</span>s
-						self.getStep <span class="reserved">import</span>ed
+						self.getStep file, <span class="reserved">import</span>ed
 				fp.read [ file.workingPath, file.name ], <span class="params">( main )</span> <span class="function">-></span>
 					pipe main, steps, <span class="params">( result )</span> <span class="function">-></span>
 						fp.write [ file.workingPath, file.name ], result, <span class="params">()</span> <span class="function">-></span> onComp<span class="reserved">let</span>e<span class="params">()</span>
@@ -941,9 +945,9 @@ _ = require <span class="string">"underscore"</span>
 			onComp<span class="reserved">let</span>e<span class="params">()</span>
 </code></pre></td></tr><tr class="block"><td class="comment"><h2>getStep</h2>
 
-<p>This is insane but it works - creating a closure around<br />a specific import to prevent accessing a changing variable.<br />* <em>import {String}</em>: the imported file to create the closure around</p></td><td class="code"><pre><code>	getStep: <span class="params">( imported )</span> <span class="function">-></span> 
+<p>This is insane but it works - creating a closure around<br />a specific import to prevent accessing a changing variable.<br />* <em>file {Object}</em> : the file we're importing into<br />* <em>import {Object}</em>: the imported file to create the closure around</p></td><td class="code"><pre><code>	getStep: <span class="params">( file, imported )</span> <span class="function">-></span> 
 		self = <span class="keyword">this</span>
-		<span class="params">( text, onDone )</span> <span class="function">-></span> self.replace text, <span class="reserved">import</span>ed, onDone
+		<span class="params">( text, onDone )</span> <span class="function">-></span> self.replace text, file, <span class="reserved">import</span>ed, onDone
 </code></pre></td></tr><tr class="block"><td class="comment"><h2>replace</h2>
 
 <p>create a replacement regex that will take the <em>imported</em> content and replace the<br />matched patterns within the main file's <em>content</em></p>
@@ -952,16 +956,19 @@ _ = require <span class="string">"underscore"</span>
 
 <ul>
 <li><em>content {Object}</em>: the content of the main file</li>
+<li><em>file {Object}</em> : the file we're importing into</li>
 <li><em>imported {Object}</em>: file metadata for the imported</li>
 <li><em>onComplete {Function}</em>: callback to invoke on completion</li>
-</ul></td><td class="code"><pre><code>	replace: <span class="params">( content, imported, onComplete )</span> <span class="function">-></span>
+</ul></td><td class="code"><pre><code>	replace: <span class="params">( content, file, imported, onComplete )</span> <span class="function">-></span>
 		patterns = @replacePatterns
 		pipe = @scheduler.pipeline
 		source = <span class="reserved">import</span>ed.name
 		working = <span class="reserved">import</span>ed.workingPath
+		relativeImportPath = path.relative<span class="params">( path.dirname( file.fullPath )</span>, path.dirname<span class="params">( imported.fullPath )</span> )
+		relativeImport = @fp.buildPath<span class="params">( [ relativeImportPath, imported.name ] )</span>
 		@fp.read [ working, source ], <span class="params">( newContent )</span> <span class="function">-></span>
 			steps = <span class="keyword">for</span> pattern <span class="keyword">in</span> patterns</code></pre></td></tr><tr class="block"><td class="comment"><p>creates a function that will replace the import statement<br />with a specific file's contents</p></td><td class="code"><pre><code>				<span class="params">( current, done )</span> <span class="function">-></span>
-					stringified = pattern.toString<span class="params">()</span>.replace ///replace///, source
+					stringified = pattern.toString<span class="params">()</span>.replace ///replace///, relativeImport
 					stringified = stringified.substring<span class="params">( <span class="number">1</span>, stringified.length - <span class="number">2</span> )</span>
 					fullPattern = <span class="keyword">new</span> RegExp stringified, <span class="string">"g"</span>					
 					capture = fullPattern.exec<span class="params">( content )</span>
@@ -1313,7 +1320,8 @@ pro = require<span class="params">( <span class="string">"uglify-js"</span> )</s
 <p>Copies the source files to the working path before beginning any processing<br />* <em>files {Array}</em>: the list of files to copy<br />* <em>onComplete {Function}</em>: the function to call once all files have been copied</p></td><td class="code"><pre><code>	copyFiles: <span class="params">( files, onComplete )</span> <span class="function">-></span>
 		fp = @fp
 		copy = <span class="params">( file, done )</span> <span class="function">-></span> 
-			fp.copy file.fullPath, [ file.workingPath, file.name ], done
+			fp.ensurePath file.workingPath, <span class="params">()</span> <span class="function">-></span> 
+				fp.copy file.fullPath, [ file.workingPath, file.name ], done
 		@scheduler.parallel files, copy, onComp<span class="reserved">let</span>e
 
 </code></pre></td></tr><tr class="block"><td class="comment"><h2>cleanWorking</h2>
@@ -1329,7 +1337,7 @@ pro = require<span class="params">( <span class="string">"uglify-js"</span> )</s
 
 <p>Determine the list of files that belong to this particular resource type<br />and create metadata objects that describe the file and provide necessary<br />metadata to the rest of the processes.<br />* <em>type {String}</em>: ('source', 'style', 'markup') <br />* <em>onComplete {Function}</em>: the function to invoke with a completed list of file metadata</p></td><td class="code"><pre><code>	prepFiles: <span class="params">( type, onComplete )</span> <span class="function">-></span>
 		self = <span class="keyword">this</span>
-		working = @config.working
+		workingBase = @config.working
 		typePath = @config[ type ]
 		output = @config.output[ type ]
 		output = <span class="keyword">if</span> _.isArray<span class="params">( output )</span> <span class="keyword">then</span> output <span class="keyword">else</span> [ output ]
@@ -1338,6 +1346,8 @@ pro = require<span class="params">( <span class="string">"uglify-js"</span> )</s
 			log.onEvent <span class="string">"Found <span class="subst">#{ files.length }</span> <span class="subst">#{ type }</span> files ..."</span>
 			list = <span class="keyword">for</span> file <span class="keyword">in</span> files
 						name = path.basename file
+						relative = path.dirname<span class="params">( file.replace( typePath, <span class="string">""</span>)</span> )
+						working = self.fp.buildPath<span class="params">( workingBase, relative )</span>
 						{
 							dependents: <span class="number">0</span>
 							ext: <span class="params">()</span> <span class="function">-></span> path.extname <span class="keyword">this</span>.name
@@ -1346,7 +1356,7 @@ pro = require<span class="params">( <span class="string">"uglify-js"</span> )</s
 							name: name
 							originalName: name
 							outputPaths: output
-							relativePath: file.replace typePath, <span class="string">""</span>
+							relativePath: relative
 							workingPath: working
 						}
 			filtered = _.filter list, <span class="params">( x )</span> <span class="function">-></span> _.any self.extensions, <span class="params">( y )</span> <span class="function">-></span> y == x.ext<span class="params">()</span>
@@ -1658,5 +1668,4 @@ express = require <span class="string">'express'</span>
 	cli = <span class="keyword">new</span> Cli<span class="params">()</span>
 	cli.run<span class="params">()</span>
 
-
-</code></pre></td></tr><tr class="block"><td class="comment"><p>this is a test</p></td><td class="code"></td></tr></table></body>
+</code></pre></td></tr></table></body>

--- a/lib/anvil.js
+++ b/lib/anvil.js
@@ -123,7 +123,7 @@ Configuration = (function() {
     var buildFile, command, exists, name, scaffold, self, type;
     self = this;
     command = new Commander();
-    command.version("0.7.6").option("-b, --build [build file]", "Use a custom build file", "./build.json").option("--ci", "Run a continuous integration build").option("--host", "Setup a static HTTP host").option("--lib [project]", "Create a lib project at the folder [project]").option("--libfile [file name]", "Create a new lib build file named [file name]").option("--site [project]", "Create a site project at the folder [project]").option("--sitefile [file name]", "Create a new site build file named [file name]").option("--mocha", "Run specifications using Mocha").option("--ape", "Create annotated source using ape").option("-q, --quiet", "Only print completion and error messages");
+    command.version("0.7.7").option("-b, --build [build file]", "Use a custom build file", "./build.json").option("--ci", "Run a continuous integration build").option("--host", "Setup a static HTTP host").option("--lib [project]", "Create a lib project at the folder [project]").option("--libfile [file name]", "Create a new lib build file named [file name]").option("--site [project]", "Create a site project at the folder [project]").option("--sitefile [file name]", "Create a new site build file named [file name]").option("--mocha", "Run specifications using Mocha").option("--ape", "Create annotated source using ape").option("-q, --quiet", "Only print completion and error messages");
     command.parse(argList);
     if (command.libfile || command.sitefile) {
       name = command.libfile || (command.libfile = command.sitefile);
@@ -835,6 +835,7 @@ Compiler = (function() {
 })();
 exports.compiler = Compiler;
 _ = require("underscore");
+path = require("path");
 Combiner = (function() {
   function Combiner(fp, scheduler, findPatterns, replacePatterns) {
     this.fp = fp;
@@ -908,7 +909,11 @@ Combiner = (function() {
         imported = imports[_j];
         importName = (imported.match(/['\"].*['\"]/))[0].replace(/['\"]/g, "");
         importedFile = _.find(list, function(i) {
-          return i.name === importName;
+          var relativeImport, relativeImportPath;
+          relativeImportPath = path.relative(path.dirname(file.fullPath), path.dirname(i.fullPath));
+          relativeImport = self.fp.buildPath([relativeImportPath, i.name]);
+          console.log("relative " + relativeImport + " actual " + importName);
+          return relativeImport === importName;
         });
         file.imports.push(importedFile);
       }
@@ -918,7 +923,7 @@ Combiner = (function() {
   Combiner.prototype.findDependents = function(file, list) {
     var imported, item, _i, _len, _results;
     imported = function(importFile) {
-      return file.name === importFile.name;
+      return file.fullPath === importFile.fullPath;
     };
     _results = [];
     for (_i = 0, _len = list.length; _i < _len; _i++) {
@@ -940,7 +945,7 @@ Combiner = (function() {
           _results = [];
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             imported = _ref[_i];
-            _results.push(self.getStep(imported));
+            _results.push(self.getStep(file, imported));
           }
           return _results;
         })();
@@ -958,19 +963,21 @@ Combiner = (function() {
       return onComplete();
     }
   };
-  Combiner.prototype.getStep = function(imported) {
+  Combiner.prototype.getStep = function(file, imported) {
     var self;
     self = this;
     return function(text, onDone) {
-      return self.replace(text, imported, onDone);
+      return self.replace(text, file, imported, onDone);
     };
   };
-  Combiner.prototype.replace = function(content, imported, onComplete) {
-    var patterns, pipe, source, working;
+  Combiner.prototype.replace = function(content, file, imported, onComplete) {
+    var patterns, pipe, relativeImport, relativeImportPath, source, working;
     patterns = this.replacePatterns;
     pipe = this.scheduler.pipeline;
     source = imported.name;
     working = imported.workingPath;
+    relativeImportPath = path.relative(path.dirname(file.fullPath), path.dirname(imported.fullPath));
+    relativeImport = this.fp.buildPath([relativeImportPath, imported.name]);
     return this.fp.read([working, source], function(newContent) {
       var pattern, steps;
       steps = (function() {
@@ -980,7 +987,7 @@ Combiner = (function() {
           pattern = patterns[_i];
           _results.push(function(current, done) {
             var capture, fullPattern, sanitized, stringified, whiteSpace;
-            stringified = pattern.toString().replace(/replace/, source);
+            stringified = pattern.toString().replace(/replace/, relativeImport);
             stringified = stringified.substring(1, stringified.length - 2);
             fullPattern = new RegExp(stringified, "g");
             capture = fullPattern.exec(content);
@@ -1415,7 +1422,9 @@ Anvil = (function() {
     var copy, fp;
     fp = this.fp;
     copy = function(file, done) {
-      return fp.copy(file.fullPath, [file.workingPath, file.name], done);
+      return fp.ensurePath(file.workingPath, function() {
+        return fp.copy(file.fullPath, [file.workingPath, file.name], done);
+      });
     };
     return this.scheduler.parallel(files, copy, onComplete);
   };
@@ -1430,15 +1439,15 @@ Anvil = (function() {
     });
   };
   Anvil.prototype.prepFiles = function(type, onComplete) {
-    var output, self, typePath, working;
+    var output, self, typePath, workingBase;
     self = this;
-    working = this.config.working;
+    workingBase = this.config.working;
     typePath = this.config[type];
     output = this.config.output[type];
     output = _.isArray(output) ? output : [output];
     log = this.log;
     return this.fp.getFiles(typePath, function(files) {
-      var file, filtered, list, name;
+      var file, filtered, list, name, relative, working;
       log.onEvent("Found " + files.length + " " + type + " files ...");
       list = (function() {
         var _i, _len, _results;
@@ -1446,6 +1455,8 @@ Anvil = (function() {
         for (_i = 0, _len = files.length; _i < _len; _i++) {
           file = files[_i];
           name = path.basename(file);
+          relative = path.dirname(file.replace(typePath, ""));
+          working = self.fp.buildPath(workingBase, relative);
           _results.push({
             dependents: 0,
             ext: function() {
@@ -1456,7 +1467,7 @@ Anvil = (function() {
             name: name,
             originalName: name,
             outputPaths: output,
-            relativePath: file.replace(typePath, ""),
+            relativePath: relative,
             workingPath: working
           });
         }

--- a/lib/anvil.js
+++ b/lib/anvil.js
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
- *	Anvil.JS v0.7.0
+ *	Anvil.JS v0.7.8
  *  Copyright (c) 2011-2012 Alex Robson
  *
  *	Permission is hereby granted, free of charge, to any person obtaining a 
@@ -912,7 +912,6 @@ Combiner = (function() {
           var relativeImport, relativeImportPath;
           relativeImportPath = path.relative(path.dirname(file.fullPath), path.dirname(i.fullPath));
           relativeImport = self.fp.buildPath([relativeImportPath, i.name]);
-          console.log("relative " + relativeImport + " actual " + importName);
           return relativeImport === importName;
         });
         file.imports.push(importedFile);
@@ -995,7 +994,7 @@ Combiner = (function() {
               whiteSpace = capture[1];
               newContent = ("" + whiteSpace) + newContent.replace(/\n/g, "\n" + whiteSpace);
             }
-            sanitized = current.replace(fullPattern, newContent.replace("\$", "$")).replace("$", "$");
+            sanitized = current.replace(fullPattern, newContent.replace("\$", "dollarh")).replace("dollarh", "$");
             return done(sanitized);
           });
         }

--- a/license.txt
+++ b/license.txt
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------------
- *	Anvil.JS v0.7.0
+ *	Anvil.JS v0.7.8
  *  Copyright (c) 2011-2012 Alex Robson
  *
  *	Permission is hereby granted, free of charge, to any person obtaining a 

--- a/next/spec/fileMachine.spec.coffee
+++ b/next/spec/fileMachine.spec.coffee
@@ -1,0 +1,33 @@
+_ = require "underscore"
+postal = require "postal"
+machina = require "machina"
+path = require "path"
+
+log = require( "./logMock.coffee" ).log
+FP = require( "./fsMock.coffee" ).fsProvider
+Scheduler = require( "../src/scheduler.js" )( _ )
+fp = new FP()
+scheduler = new Scheduler()
+Combiner = require( "../src/combiner.js" )( _, fp, scheduler )
+FM = require( "../src/fileMachine.js" )( _, fp, scheduler, postal, machina )
+
+require "should"
+
+
+coffeeOne = """
+class Test
+	method: () ->
+		console.log "I'm a coffee file, yo!"
+"""
+
+
+describe "creating files for tests", () ->
+
+	before ( done ) ->
+		scheduler.
+
+describe "when creating a new file state machine", () ->
+
+
+
+	before ( done ) ->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "anvil.js",
     "description": "A continuous integration tool for JS, CSS and HTML.",
-    "version": "0.7.7",
+    "version": "0.7.8",
     "authors": ["Alex Robson <@A_Robson>"],
     "keywords": ["build","compile","static","ci"],
     "main": "./lib/anvil.js",

--- a/src/combiner.coffee
+++ b/src/combiner.coffee
@@ -89,7 +89,6 @@ class Combiner
 				importedFile = _.find( list, ( i ) -> 
 					relativeImportPath = path.relative( path.dirname( file.fullPath ), path.dirname( i.fullPath ) )
 					relativeImport = self.fp.buildPath( [ relativeImportPath, i.name ] )
-					console.log "relative #{ relativeImport } actual #{ importName }"
 					relativeImport == importName )
 				file.imports.push importedFile
 			onComplete()


### PR DESCRIPTION
Added support for relative import statements. (thanks @robertmesserle for helping with ideas and pushing me to get this done). Don't prefix the import path with a ./ or /, Anvil won't recognize that as a match.
### Examples of (now valid) import statements:

**To import a file in the same directory:**
    // import( "child.js" );

**To import a file from a subdirectory:**
    // import( "subdir/child.js" );

**To import a file from a parent directory:**
    // import( "../parent.js" );

**To import a file from a sibling directory:**
    // import( "../sibling/file.js" );
