### PR TITLE
Show error when importing a file that doesn't exists

### DIFF
--- a/src/combiner.coffee
+++ b/src/combiner.coffee
@@ -90,10 +90,10 @@ class Combiner
 					relativeImportPath = path.relative( path.dirname( file.fullPath ), path.dirname( i.fullPath ) )
 					relativeImport = self.fp.buildPath( [ relativeImportPath, i.name ] )
 					relativeImport == importName )
-                if not self.fp.pathExists [ file.workingPath, importName ]
-                    log.onError "Could not find import file #{ importName } from #{ file.name }"
-                else
-				    file.imports.push importedFile
+				if not self.fp.pathExists [ file.workingPath, importName ]
+					log.onError "Could not find import file #{ importName } from #{ file.name }"
+				else
+					file.imports.push importedFile
 			onComplete()
 
 	# ## fileDependents ##

--- a/src/combiner.coffee
+++ b/src/combiner.coffee
@@ -90,7 +90,10 @@ class Combiner
 					relativeImportPath = path.relative( path.dirname( file.fullPath ), path.dirname( i.fullPath ) )
 					relativeImport = self.fp.buildPath( [ relativeImportPath, i.name ] )
 					relativeImport == importName )
-				file.imports.push importedFile
+                if not self.fp.pathExists [ file.workingPath, importName ]
+                    log.onError "Could not find import file #{ importName } from #{ file.name }"
+                else
+				    file.imports.push importedFile
 			onComplete()
 
 	# ## fileDependents ##


### PR DESCRIPTION
Hello, I have found that if you try to import a file that doesn't exists it fails with the following error:

```
/usr/local/lib/node_modules/anvil.js/lib/anvil.js:925
      return file.fullPath === importFile.fullPath;
                                         ^
TypeError: Cannot read property 'fullPath' of undefined
      at Combiner.findDependents.imported (/usr/local/lib/node_modules/anvil.js/lib/anvil.js:925:42)
      ...
```

If you mistype the filename on an import statement I find that this error is not very helpful because it doesn't say which file fails.

I have modified the function `findImports` from `combiner.coffee` to show an error message if the imported file doesn't exists, **anvil** doesn't abort but the file isn't pushed to `imports`.

I hope this code is okay and helpful to somebody.
