### PR TITLE
Modified Script Injection

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -160,7 +160,6 @@ var configFactory = function( _, commander, path, anvil ) {
 		} catch ( err ) {
 			anvil.log.error( "Error processing arguments (" + this.args + ") :" + err + "\n" + err.stack );
 		}
-		console.log( defaultConfig, anvil.config, anvil.loadedConfig );
 		var config = _.deepExtend( defaultConfig, anvil.config, anvil.loadedConfig );
 		this.checkDirectories( config );
 		anvil.onConfig( config );

--- a/lib/host.js
+++ b/lib/host.js
@@ -16,6 +16,36 @@ var open = require( "open" );
 var url = require( "url" );
 var net = require( "net" );
 
+var getScriptInjection = function() {
+	return [
+		 '<script type="text/javascript">'
+		,'	(function(window, undefined){'
+		,'		function loadScript(src) {'
+		,'			var script = document.createElement("script");'
+		,'			script.src = src;'
+		,'			script.type = "text/javascript";'
+		,'			document.getElementsByTagName("body")[0].appendChild(script);'
+		,'		}'
+		,'		if(typeof io === "undefined") {'
+		,'			if ( typeof define === "function" && define.amd ) {'
+		,'			require.config({'
+		,'			    paths: {'
+		,'			        "io" : "/socket.io/socket.io"'
+		,'			    }'
+		,'		    });'
+		,'		    require(["io"], function(io) {'
+		,'			    loadScript("/anvil/buildHook.js");'
+		,'			});'
+		,'		} else {'
+		,'			loadScript("/socket.io/socket.io.js");'
+		,'			loadScript("/anvil/buildHook.js");'
+		,'			}'
+		,'		}'
+		,'	}(window));'
+		,'</script>'
+	].join('\n');
+};
+
 module.exports = function( _, anvil ) {
 	
 	var Host = function() {
@@ -103,7 +133,7 @@ module.exports = function( _, anvil ) {
 			var original = body.toString();
 			if( original.match( /[<][\/]body[>]/ ) ) {
 				var modified = original.replace( /[<][\/]body[>]/,
-					"<script src=\"/socket.io/socket.io.js\"></script>\n<script src=\"/anvil/buildHook.js\"></script>\n</body>"
+					getScriptInjection() + "\n</body>"
 				);
 				res._headers[ "content-length" ] = modified.length;
 				res.end( modified );

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "main": "./lib/api.js",
   "scripts": {
     "install": "npm link npm --local",
-    "postinstall": "node ./init.js"
+    "postinstall": "node ./init.js",
+	"test": "anvil --testem"
   },
   "licenses": [
     {


### PR DESCRIPTION
The current script injection includes socket.io as an anonymous module if the hosted page has require.js (or another AMD loader) present, resulting in the following error:

`Uncaught Error: Mismatched anonymous define() module: function () { return io; }`

This means that any anvil-hosted assets using AMD will fail. I've modified what gets injected so that it's a single script tag that tests for amd. If amd is detected, it will set up a named path for socket.io via require.config() and then require the socket.io client lib. Once the lib is present, the anvil buildHook.js file is included. If amd is not detected, both socket.io and the buildHook.js file are pulled the old fashioned way (via adding script tags to the body).
